### PR TITLE
Convert code HTML tags to the rocketchat syntax and remove all others

### DIFF
--- a/lib/xify/output/rocket_chat.rb
+++ b/lib/xify/output/rocket_chat.rb
@@ -9,6 +9,7 @@ module Xify
     class RocketChat < Base::RocketChat
       def process(event)
         request :post, '/api/v1/chat.postMessage' do |req|
+          filtered_message = filter_tags(event.message.chomp)
           req['Content-Type'] = 'application/json'
           req.body = {
             channel: @config['channel'],
@@ -17,11 +18,16 @@ module Xify
               {
                 title: event.args[:parent],
                 title_link: event.args[:parent_link],
-                text: event.args[:link] ? "#{event.message.chomp}\n\n([link to source](#{event.args[:link]}))" : event.message.chomp
+                text: event.args[:link] ? "#{filtered_message}\n\n([link to source](#{event.args[:link]}))" : filtered_message
               }
             ]
           }.to_json
         end
+      end
+
+      private
+      def filter_tags(string)
+        string.gsub(/\<\/code\>/, '```').gsub(/```(.*)```/, '`$1`').gsub(/\<\/?[^>]\>/, '')
       end
     end
   end


### PR DESCRIPTION
I was annoyed by the mixed syntax which xify currently outputs.
As there is no configuration for such filters, its directly injected into the rocketchat output plugin.

If you have a better Idea which does not entail too much work I'd consider reworking this change.